### PR TITLE
Emission Line and UV Luminosity

### DIFF
--- a/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
+++ b/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
@@ -331,6 +331,7 @@ def plot_n_corner(
             "density": True,
         },
         fill_contours=False,
+        plot_density=False,
         contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
         range=ranges,
     )
@@ -355,6 +356,7 @@ def plot_n_corner(
             "density": True,
         },
         fill_contours=False,
+        plot_density=False,
         contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
         range=ranges,
     )
@@ -378,6 +380,7 @@ def plot_n_corner(
                 "density": True,
             },
             # hist2d_kwargs={"weights": weights2},
+            plot_density=False,
             fill_contours=False,
             contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
             range=ranges,

--- a/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
+++ b/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
@@ -286,7 +286,7 @@ def plot_n_mag(
     ax[0].set_ylabel("\u03d5 [Mpc$^{-3}$]", fontsize=fontsize)
     plt.rcParams["legend.fontsize"] = legend_fontsize
     ax[-1].legend(framealpha=0.5, loc="upper left", bbox_to_anchor=(-2, 1.2), ncols=3)
-    plt.savefig(saveAs + ".pdf")
+    plt.savefig(saveAs + ".png")
     plt.show()
 
 
@@ -405,7 +405,7 @@ def plot_n_corner(
 
     for ax in fig_corner.get_axes():
         ax.tick_params(axis="both", direction="in", labelsize=labelsize)
-    plt.savefig(saveAs + "_corner.pdf")
+    plt.savefig(saveAs + "_corner.png")
     plt.show()
 
 
@@ -686,7 +686,7 @@ def plot_n(
     plt.rcParams["legend.fontsize"] = legend_fontsize
     ax[-1].legend(framealpha=0.5, loc="upper left", bbox_to_anchor=(-2, 1.2), ncols=3)
 
-    plt.savefig(saveAs + ".pdf")
+    plt.savefig(saveAs + ".png")
     plt.show()
 
     # Output loss based on lh_centroids, not 1D histograms as above,

--- a/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
+++ b/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
@@ -218,9 +218,11 @@ def plot_n_mag(
             ]
         )
 
-    fig, ax = plt.subplots(1, n_bands, figsize=(2.5 * n_bands, 4), squeeze=False)
+    fig, ax = plt.subplots(1, n_bands, figsize=(2.5 * n_bands, 4.5), squeeze=False)
     ax = ax[0]  # flatten from shape (1, n_bands) → (n_bands,)
-    fig.subplots_adjust(left=0.1, hspace=0, top=0.8, right=0.99, bottom=0.2, wspace=0.0)
+    fig.subplots_adjust(
+        left=0.05, hspace=0, top=0.8, right=0.99, bottom=0.2, wspace=0.0
+    )
     fig.suptitle(title, fontsize=18)
 
     mag_bin_edges = np.arange(18.0 - dmag / 2, mag_thresh, dmag)
@@ -352,7 +354,7 @@ def plot_n_corner(
         hist_kwargs={
             "histtype": "step",
             "alpha": 0.5,
-            "lw": lw + 1,
+            "lw": lw + 2,
             "density": True,
         },
         fill_contours=False,
@@ -376,7 +378,7 @@ def plot_n_corner(
             hist_kwargs={
                 "histtype": "step",
                 "alpha": 0.5,
-                "lw": lw + 1,
+                "lw": lw + 2,
                 "density": True,
             },
             # hist2d_kwargs={"weights": weights2},
@@ -631,11 +633,13 @@ def plot_n(
     fig, ax = plt.subplots(
         1,
         n_bands - 1 + len(mag_columns),
-        figsize=(2.5 * n_bands - 1 + len(mag_columns), 4),
+        figsize=(2.5 * n_bands - 1 + len(mag_columns), 4.5),
         squeeze=False,
     )
     ax = ax[0]  # flatten from shape (1, n_bands) → (n_bands,)
-    fig.subplots_adjust(left=0.1, hspace=0, top=0.8, right=0.99, bottom=0.2, wspace=0.0)
+    fig.subplots_adjust(
+        left=0.05, hspace=0, top=0.8, right=0.99, bottom=0.2, wspace=0.0
+    )
     fig.suptitle(title, fontsize=18)
 
     for i in range(0, n_bands - 1 + len(mag_columns)):

--- a/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
+++ b/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
@@ -36,7 +36,7 @@ alpha2 = 0.7
 alpha_data = 0.5
 
 
-lw = 1
+lw = 1.5
 fontsize = 20
 labelsize = 12
 legend_fontsize = 14
@@ -332,7 +332,7 @@ def plot_n_corner(
         },
         fill_contours=False,
         plot_density=False,
-        contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
+        contour_kwargs={"linewidths": 3.5, "alpha": 0.75},
         range=ranges,
     )
 
@@ -357,7 +357,7 @@ def plot_n_corner(
         },
         fill_contours=False,
         plot_density=False,
-        contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
+        contour_kwargs={"linewidths": 3.5, "alpha": 0.75},
         range=ranges,
     )
 
@@ -382,7 +382,7 @@ def plot_n_corner(
             # hist2d_kwargs={"weights": weights2},
             plot_density=False,
             fill_contours=False,
-            contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
+            contour_kwargs={"linewidths": 3.5, "alpha": 0.75},
             range=ranges,
         )
 

--- a/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
+++ b/diffhtwo/experimental/diagnostics/plot_mag_color_1d_hist.py
@@ -330,7 +330,7 @@ def plot_n_corner(
             "lw": lw,
             "density": True,
         },
-        fill_contours=True,
+        fill_contours=False,
         contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
         range=ranges,
     )
@@ -354,7 +354,7 @@ def plot_n_corner(
             "lw": lw + 1,
             "density": True,
         },
-        fill_contours=True,
+        fill_contours=False,
         contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
         range=ranges,
     )
@@ -378,7 +378,7 @@ def plot_n_corner(
                 "density": True,
             },
             # hist2d_kwargs={"weights": weights2},
-            fill_contours=True,
+            fill_contours=False,
             contour_kwargs={"linewidths": 2.5, "alpha": 0.75},
             range=ranges,
         )

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -6,6 +6,7 @@ jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_debug_infs", True)
 import jax.numpy as jnp
+from diffsky import diffndhist
 from diffsky.dustpop import tw_dustpop_mono_noise
 from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
 from diffsky.experimental.kernels import mc_phot_kernels as mcpk

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -54,7 +54,6 @@ def compute_emline_luminosity(
     phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
         ran_key, diffstarpop_params, mah_params, cosmo_params
     )
-    print("phot_randoms:{}", phot_randoms)
 
     t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
         mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
@@ -102,13 +101,9 @@ def compute_emline_luminosity(
     integrand = ssp_emline_luminosity * ssp_weights * frac_trans
     L_emline_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
-    print("L_emline_cgs:{}", L_emline_cgs)
-
     # no dust
     integrand_nodust = ssp_emline_luminosity * ssp_weights
     L_emline_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
-
-    print("L_emline_cgs_nodust:{}", L_emline_cgs_nodust)
 
     return L_emline_cgs, L_emline_cgs_nodust
 

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -20,12 +20,6 @@ LGMET_SCATTER = 0.2
 # copied from astropy.constants.L_sun.cgs.value
 L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
 
-# copied from astropy.constants.c.value in m/s
-C = 299792458.0
-
-# halpha rest wavelength center in fsps
-HALPHA_CENTER_AA = 6564.5131
-
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
 _calc_dust_ftrans_vmap = jjit(
     vmap(
@@ -36,7 +30,7 @@ _calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def compute_halpha_luminosity(
+def compute_emline_luminosity(
     ran_key,
     z_obs,
     t_obs,
@@ -47,7 +41,8 @@ def compute_halpha_luminosity(
     scatter_params,
     t_table,
     ssp_data,
-    ssp_halpha_luminosity,
+    emline_wave_aa,
+    ssp_emline_luminosity,
     cosmo_params,
     fb,
     lgmet_scatter=LGMET_SCATTER,
@@ -80,7 +75,7 @@ def compute_halpha_luminosity(
 
     ftrans_args = (
         spspop_params.dustpop_params,
-        HALPHA_CENTER_AA,
+        emline_wave_aa,
         logsm_obs,
         logssfr_obs,
         z_obs,
@@ -100,11 +95,11 @@ def compute_halpha_luminosity(
     frac_trans = frac_trans.reshape(n_gals, 1, n_age)
 
     _mstar = 10**logsm_obs
-    integrand = ssp_halpha_luminosity * ssp_weights * frac_trans
-    L_halpha_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
+    integrand = ssp_emline_luminosity * ssp_weights * frac_trans
+    L_emline_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
     # no dust
-    integrand_nodust = ssp_halpha_luminosity * ssp_weights
-    L_halpha_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
+    integrand_nodust = ssp_emline_luminosity * ssp_weights
+    L_emline_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
-    return L_halpha_cgs, L_halpha_cgs_nodust
+    return L_emline_cgs, L_emline_cgs_nodust

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -6,13 +6,14 @@ jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_debug_infs", True)
 import jax.numpy as jnp
-from diffsky import diffndhist
 from diffsky.dustpop import tw_dustpop_mono_noise
 from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
 from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
+
+from . import diffndhist as diffndhist2
 
 # from jax.debug import print
 
@@ -127,6 +128,9 @@ def get_emline_luminosity_func(
     weights : array of shape (n,)
         weights to multiply with L_emline_cgs
 
+    sig : array of shape (nbins, 1)
+        bin dependent sigma for diffndhist
+
     Returns
     -------
     lgL_bin_edges : array of luminosity function bin edges in log10-space
@@ -141,9 +145,6 @@ def get_emline_luminosity_func(
     # mask: valid (strictly positive & finite)
     valid = jnp.isfinite(L_emline) & (L_emline > 0)
     L_emline = jnp.where(valid, L_emline, 10)
-
-    # # safe log10: put invalids far below the underflow bin (won't matter b/c weight=0)
-    # lg_floor = lgL_min - 10.0
     lgL_emline = jnp.log10(L_emline)
 
     # weights: zero-out invalids
@@ -157,19 +158,17 @@ def get_emline_luminosity_func(
         0.0,
     )
 
-    if sig is None:
-        sig_arr = jnp.zeros_like(lgL_emline) + (dlgL_bin / 2)
-    else:
-        sig_arr = jnp.zeros_like(lgL_emline) + sig
-
     if lgL_bin_edges is None:
         lgL_bin_edges = jnp.arange(lgL_min, lgL_max, dlgL_bin)
 
     lgL_bin_lo = lgL_bin_edges[:-1].reshape(lgL_bin_edges[:-1].size, 1)
     lgL_bin_hi = lgL_bin_edges[1:].reshape(lgL_bin_edges[1:].size, 1)
 
-    tw_hist_weighted = diffndhist.tw_ndhist_weighted(
-        lgL_emline, sig_arr, w, lgL_bin_lo, lgL_bin_hi
+    if sig is None:
+        sig = jnp.zeros_like(lgL_bin_lo) + (dlgL_bin / 2)
+
+    tw_hist_weighted = diffndhist2.tw_ndhist_weighted(
+        lgL_emline, sig, w, lgL_bin_lo, lgL_bin_hi
     )
 
     return lgL_bin_edges, tw_hist_weighted

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -12,6 +12,7 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
+from jax.debug import print
 
 from . import diffndhist as diffndhist2
 
@@ -53,6 +54,7 @@ def compute_emline_luminosity(
     phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
         ran_key, diffstarpop_params, mah_params, cosmo_params
     )
+    print("phot_randoms:{}", phot_randoms)
 
     t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
         mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
@@ -100,9 +102,13 @@ def compute_emline_luminosity(
     integrand = ssp_emline_luminosity * ssp_weights * frac_trans
     L_emline_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
+    print("L_emline_cgs:{}", L_emline_cgs)
+
     # no dust
     integrand_nodust = ssp_emline_luminosity * ssp_weights
     L_emline_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
+
+    print("L_emline_cgs_nodust:{}", L_emline_cgs_nodust)
 
     return L_emline_cgs, L_emline_cgs_nodust
 

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -103,3 +103,72 @@ def compute_emline_luminosity(
     L_emline_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
     return L_emline_cgs, L_emline_cgs_nodust
+
+
+@jjit
+def get_emline_luminosity_func(
+    L_emline_cgs,
+    weights,
+    dlgL_bin=0.2,
+    lgL_min=38.0,
+    lgL_max=45.0,
+    sig=None,
+    lgL_bin_edges=None,
+):
+    """
+    Calculates the emline LF
+
+    Parameters
+    ----------
+    L_emline_cgs : array of shape (n,) or (n, 1)
+        h-alpha Luminosities in [erg/s]
+
+    weights : array of shape (n,)
+        weights to multiply with L_emline_cgs
+
+    Returns
+    -------
+    lgL_bin_edges : array of luminosity function bin edges in log10-space
+        defined using default arguments of this function.
+    tw_hist_weighted:
+        luminosity function - weighted histogram counts using diffsky.diffndhist
+    """
+
+    n_L = L_emline_cgs.size
+    L_emline = L_emline_cgs.reshape(n_L, 1)
+
+    # mask: valid (strictly positive & finite)
+    valid = jnp.isfinite(L_emline) & (L_emline > 0)
+    L_emline = jnp.where(valid, L_emline, 10)
+
+    # # safe log10: put invalids far below the underflow bin (won't matter b/c weight=0)
+    # lg_floor = lgL_min - 10.0
+    lgL_emline = jnp.log10(L_emline)
+
+    # weights: zero-out invalids
+    w = jnp.where(
+        valid.reshape(
+            n_L,
+        ),
+        weights.reshape(
+            n_L,
+        ),
+        0.0,
+    )
+
+    if sig is None:
+        sig_arr = jnp.zeros_like(lgL_emline) + (dlgL_bin / 2)
+    else:
+        sig_arr = jnp.zeros_like(lgL_emline) + sig
+
+    if lgL_bin_edges is None:
+        lgL_bin_edges = jnp.arange(lgL_min, lgL_max, dlgL_bin)
+
+    lgL_bin_lo = lgL_bin_edges[:-1].reshape(lgL_bin_edges[:-1].size, 1)
+    lgL_bin_hi = lgL_bin_edges[1:].reshape(lgL_bin_edges[1:].size, 1)
+
+    tw_hist_weighted = diffndhist.tw_ndhist_weighted(
+        lgL_emline, sig_arr, w, lgL_bin_lo, lgL_bin_hi
+    )
+
+    return lgL_bin_edges, tw_hist_weighted

--- a/diffhtwo/experimental/emline_luminosity.py
+++ b/diffhtwo/experimental/emline_luminosity.py
@@ -12,11 +12,8 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-from jax.debug import print
 
 from . import diffndhist as diffndhist2
-
-# from jax.debug import print
 
 LGMET_SCATTER = 0.2
 

--- a/diffhtwo/experimental/halpha_luminosity2.py
+++ b/diffhtwo/experimental/halpha_luminosity2.py
@@ -27,7 +27,7 @@ C = 299792458.0
 HALPHA_CENTER_AA = 6564.5131
 
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
-calc_dust_ftrans_vmap = jjit(
+_calc_dust_ftrans_vmap = jjit(
     vmap(
         tw_dustpop_mono_noise.calc_ftrans_singlegal_singlewave_from_dustpop_params,
         in_axes=_D,
@@ -92,7 +92,7 @@ def compute_halpha_luminosity(
     )
 
     # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
-    _res_dust = calc_dust_ftrans_vmap(*ftrans_args)
+    _res_dust = _calc_dust_ftrans_vmap(*ftrans_args)
 
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
     frac_trans = _res_dust[1]

--- a/diffhtwo/experimental/halpha_luminosity2.py
+++ b/diffhtwo/experimental/halpha_luminosity2.py
@@ -103,4 +103,8 @@ def compute_halpha_luminosity(
     integrand = ssp_halpha_luminosity * ssp_weights * frac_trans
     L_halpha_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
 
-    return L_halpha_cgs
+    # no dust
+    integrand_nodust = ssp_halpha_luminosity * ssp_weights
+    L_halpha_cgs_nodust = jnp.sum(integrand_nodust, axis=(1, 2)) * (L_SUN_CGS * _mstar)
+
+    return L_halpha_cgs, L_halpha_cgs_nodust

--- a/diffhtwo/experimental/halpha_luminosity2.py
+++ b/diffhtwo/experimental/halpha_luminosity2.py
@@ -1,0 +1,106 @@
+# flake8: noqa: E402
+""" """
+import jax
+
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_debug_nans", True)
+jax.config.update("jax_debug_infs", True)
+import jax.numpy as jnp
+from diffsky.dustpop import tw_dustpop_mono_noise
+from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
+from diffsky.experimental.kernels import mc_phot_kernels as mcpk
+from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
+from jax import jit as jjit
+from jax import vmap
+
+# from jax.debug import print
+
+LGMET_SCATTER = 0.2
+
+# copied from astropy.constants.L_sun.cgs.value
+L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
+
+# copied from astropy.constants.c.value in m/s
+C = 299792458.0
+
+# halpha rest wavelength center in fsps
+HALPHA_CENTER_AA = 6564.5131
+
+_D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
+calc_dust_ftrans_vmap = jjit(
+    vmap(
+        tw_dustpop_mono_noise.calc_ftrans_singlegal_singlewave_from_dustpop_params,
+        in_axes=_D,
+    )
+)
+
+
+@jjit
+def compute_halpha_luminosity(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    diffstarpop_params,
+    spspop_params,
+    mzr_params,
+    scatter_params,
+    t_table,
+    ssp_data,
+    ssp_halpha_luminosity,
+    cosmo_params,
+    fb,
+    lgmet_scatter=LGMET_SCATTER,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
+        ran_key, diffstarpop_params, mah_params, cosmo_params
+    )
+
+    t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
+        mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
+    )
+
+    age_weights_smooth, lgmet_weights = sspwk.get_smooth_ssp_weights(
+        t_table, sfh_table, logsm_obs, ssp_data, t_obs, mzr_params, LGMET_SCATTER
+    )
+
+    _res = sspwk.compute_burstiness(
+        phot_randoms.uran_pburst,
+        phot_randoms.mc_is_q,
+        logsm_obs,
+        logssfr_obs,
+        age_weights_smooth,
+        lgmet_weights,
+        ssp_data,
+        spspop_params.burstpop_params,
+    )
+
+    ssp_weights, burst_params, mc_sfh_type = _res
+
+    ftrans_args = (
+        spspop_params.dustpop_params,
+        HALPHA_CENTER_AA,
+        logsm_obs,
+        logssfr_obs,
+        z_obs,
+        ssp_data.ssp_lg_age_gyr,
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        scatter_params,
+    )
+
+    # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
+    _res_dust = calc_dust_ftrans_vmap(*ftrans_args)
+
+    # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
+    frac_trans = _res_dust[1]
+    n_gals, n_age = frac_trans.shape
+    frac_trans = frac_trans.reshape(n_gals, 1, n_age)
+
+    _mstar = 10**logsm_obs
+    integrand = ssp_halpha_luminosity * ssp_weights * frac_trans
+    L_halpha_cgs = jnp.sum(integrand, axis=(1, 2)) * (L_SUN_CGS * _mstar)
+
+    return L_halpha_cgs

--- a/diffhtwo/experimental/n_mag.py
+++ b/diffhtwo/experimental/n_mag.py
@@ -16,6 +16,9 @@ from jax.debug import print
 
 from . import diffndhist as diffndhist2
 
+N_FLOOR = 0.5
+N_0 = 1e-12
+
 
 @jjit
 def n_mag_kern(
@@ -629,9 +632,8 @@ def Gehrels_low_eq12(Ngal):
 
 
 @jjit
-def get_n_data_err(N, vol, N_floor=0.5):
-    N_0 = 1e-12
-    non_zero = N > N_floor
+def get_n_data_err(N, vol):
+    non_zero = N > N_FLOOR
 
     N = jnp.where(non_zero, N, N_0)
     lg_n = jnp.log10(N / vol)

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -558,11 +558,9 @@ def get_halpha_loss(
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
-
+    print("halpha_N:{}", halpha_N)
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
     halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, 1e-1)
-    print("halpha_N:{}", halpha_N)
-    print("lc_vol_mpc3:{}", lc_vol_mpc3)
 
     lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
 

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -33,6 +33,7 @@ from jax.flatten_util import ravel_pytree
 from diffhtwo.experimental.utils import safe_log10
 
 from . import diffstarpop_halpha as dpop_halpha
+from . import emline_luminosity
 from .n_mag import n_mag_kern, n_mag_kern_1d, n_mag_kern_nocolor
 
 u_diffstarpop_theta_default, u_diffstarpop_unravel = ravel_pytree(
@@ -520,8 +521,6 @@ def get_halpha_loss(
     lg_halpha_LF_target,
     lg_halpha_Lbin_edges,
     lg_n_thresh,
-    halpha_LF_zmin,
-    halpha_LF_zmax,
     lc_z_obs,
     lc_t_obs,
     lc_mah_params,
@@ -537,52 +536,34 @@ def get_halpha_loss(
     cosmo_params,
     fb,
 ):
-    z_phot_table = jnp.linspace(halpha_LF_zmin, halpha_LF_zmax, 10)
-    halpha_args = (
-        diffstarpop_params,
+    L_halpha_cgs, _ = emline_luminosity.compute_emline_luminosity(
         ran_key,
         lc_z_obs,
         lc_t_obs,
         lc_mah_params,
-        lc_logmp0,
+        diffstarpop_params,
+        spspop_params,
+        mzr_params,
+        scatter_params,
         t_table,
         ssp_data,
+        halpha_wave_aa,
         ssp_halpha_luminosity,
-        z_phot_table,
-        mzr_params,
-        spspop_params,
-        scatter_params,
         cosmo_params,
         fb,
     )
-    halpha_L = dpop_halpha.diffstarpop_halpha_kern(*halpha_args)
-    sig = jnp.mean(jnp.diff(lg_halpha_Lbin_edges)) / 2
-    (
-        _,
-        halpha_lf_weighted_q,
-        halpha_lf_weighted_smooth_ms,
-        halpha_lf_weighted_bursty_ms,
-    ) = dpop_halpha.diffstarpop_halpha_lf_weighted_lc_weighted(
-        halpha_L,
-        lc_nhalos,
-        sig=sig,
-        lgL_bin_edges=lg_halpha_Lbin_edges,
-    )
 
-    halpha_lf_weighted_composite = (
-        halpha_lf_weighted_q
-        + halpha_lf_weighted_smooth_ms
-        + halpha_lf_weighted_bursty_ms
+    sig = jnp.mean(jnp.diff(lg_halpha_Lbin_edges)) / 2
+    _, halpha_N = emline_luminosity.get_emline_luminosity_func(
+        L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
 
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
     N_0 = 1e-12
     N_floor = 0.5
-    halpha_lf_weighted_composite = jnp.where(
-        halpha_lf_weighted_composite > N_floor, halpha_lf_weighted_composite, N_0
-    )
+    halpha_N = jnp.where(halpha_N > N_floor, halpha_N, N_0)
 
-    lg_halpha_LF_model = jnp.log10(halpha_lf_weighted_composite / lc_vol_mpc3)
+    lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
 
     return _mse_w(
         lg_halpha_LF_model,
@@ -623,8 +604,6 @@ def _loss_kern(
     ssp_halpha_luminosity=None,
     lg_halpha_LF_target=None,
     lg_halpha_Lbin_edges=None,
-    halpha_LF_zmin=None,
-    halpha_LF_zmax=None,
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
@@ -699,8 +678,6 @@ def _loss_kern(
             lg_halpha_LF_target,
             lg_halpha_Lbin_edges,
             lg_n_thresh,
-            halpha_LF_zmin,
-            halpha_LF_zmax,
             halpha_lc_z_obs,
             halpha_lc_t_obs,
             halpha_lc_mah_params,
@@ -756,8 +733,6 @@ def fit_n(
     ssp_halpha_luminosity=None,
     lg_halpha_LF_target=None,
     lg_halpha_Lbin_edges=None,
-    halpha_LF_zmin=None,
-    halpha_LF_zmax=None,
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
@@ -796,8 +771,6 @@ def fit_n(
         ssp_halpha_luminosity,
         lg_halpha_LF_target,
         lg_halpha_Lbin_edges,
-        halpha_LF_zmin,
-        halpha_LF_zmax,
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,
@@ -847,8 +820,6 @@ _L = (
     None,
     None,
     None,
-    0,
-    0,
     0,
     0,
     0,
@@ -907,8 +878,6 @@ def fit_n_multi_z(
     ssp_halpha_luminosity=None,
     lg_halpha_LF_target=None,
     lg_halpha_Lbin_edges=None,
-    halpha_LF_zmin=None,
-    halpha_LF_zmax=None,
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
@@ -947,8 +916,6 @@ def fit_n_multi_z(
         ssp_halpha_luminosity,
         lg_halpha_LF_target,
         lg_halpha_Lbin_edges,
-        halpha_LF_zmin,
-        halpha_LF_zmax,
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,
@@ -1101,8 +1068,6 @@ def _loss_kern_w_nbs(
     ssp_halpha_luminosity=None,
     lg_halpha_LF_target=None,
     lg_halpha_Lbin_edges=None,
-    halpha_LF_zmin=None,
-    halpha_LF_zmax=None,
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
@@ -1213,8 +1178,6 @@ def _loss_kern_w_nbs(
             lg_halpha_LF_target,
             lg_halpha_Lbin_edges,
             lg_n_thresh,
-            halpha_LF_zmin,
-            halpha_LF_zmax,
             halpha_lc_z_obs,
             halpha_lc_t_obs,
             halpha_lc_mah_params,
@@ -1272,8 +1235,6 @@ _L_w_nbs = (
     None,
     None,
     None,
-    0,
-    0,
     0,
     0,
     0,
@@ -1342,8 +1303,6 @@ def fit_n_w_nbs_multi_z(
     ssp_halpha_luminosity=None,
     lg_halpha_LF_target=None,
     lg_halpha_Lbin_edges=None,
-    halpha_LF_zmin=None,
-    halpha_LF_zmax=None,
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
@@ -1392,8 +1351,6 @@ def fit_n_w_nbs_multi_z(
         ssp_halpha_luminosity,
         lg_halpha_LF_target,
         lg_halpha_Lbin_edges,
-        halpha_LF_zmin,
-        halpha_LF_zmax,
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -555,7 +555,7 @@ def get_halpha_loss(
 
     sig = jnp.diff(lg_halpha_Lbin_edges) / 2
     sig = sig.reshape(sig.size, 1)
-    print("lg_halpha_Lbin_edges"{}, lg_halpha_Lbin_edges)
+    print("lg_halpha_Lbin_edges:{}", lg_halpha_Lbin_edges)
     print("sig:{}", sig)
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -537,6 +537,7 @@ def get_halpha_loss(
     cosmo_params,
     fb,
 ):
+    print("lc_mah_params.shape:{}", lc_mah_params.shape)
     L_halpha_cgs, _ = emline_luminosity.compute_emline_luminosity(
         ran_key,
         lc_z_obs,

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -557,7 +557,6 @@ def get_halpha_loss(
 
     sig = jnp.diff(lg_halpha_Lbin_edges) / 2
     sig = sig.reshape(sig.size, 1)
-    print("sig.shape:{}", sig.shape)
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -691,6 +691,7 @@ def _loss_kern(
             cosmo_params,
             fb,
         )
+        print("halpha_loss:{}", get_halpha_loss(*halpha_loss_args))
         loss += get_halpha_loss(*halpha_loss_args)
 
     return loss

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -558,11 +558,15 @@ def get_halpha_loss(
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
+    print("halpha_N:{}", halpha_N)
+    print("jnp.sum(halpha_N):{}", jnp.sum(halpha_N))
 
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
     halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
 
     lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
+
+    print("lg_halpha_LF_model:{}", lg_halpha_LF_model)
 
     return _mse_w(
         lg_halpha_LF_model,

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -560,7 +560,7 @@ def get_halpha_loss(
     )
 
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
-    halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
+    halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, 1e-1)
     print("halpha_N:{}", halpha_N)
     print("lc_vol_mpc3:{}", lc_vol_mpc3)
 

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -672,6 +672,7 @@ def _loss_kern(
         frac_cat,
     )
     loss = _mse_w(lg_n_model, lg_n_target[0], lg_n_target[1], lg_n_thresh)
+    print("loss:{}", loss)
 
     if lg_halpha_LF_target is not None:
         halpha_lc_mah_params = DiffmahParams(*halpha_lc_mah_params)

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -555,12 +555,14 @@ def get_halpha_loss(
 
     sig = jnp.diff(lg_halpha_Lbin_edges) / 2
     sig = sig.reshape(sig.size, 1)
+    print("lg_halpha_Lbin_edges"{}, lg_halpha_Lbin_edges)
+    print("sig:{}", sig)
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
     print("halpha_N:{}", halpha_N)
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
-    halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, 1e-1)
+    halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
 
     lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
 

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -558,15 +558,13 @@ def get_halpha_loss(
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
-    print("halpha_N:{}", halpha_N)
-    print("jnp.sum(halpha_N):{}", jnp.sum(halpha_N))
 
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
     halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
+    print("halpha_N:{}", halpha_N)
+    print("lc_vol_mpc3:{}", lc_vol_mpc3)
 
     lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
-
-    print("lg_halpha_LF_model:{}", lg_halpha_LF_model)
 
     return _mse_w(
         lg_halpha_LF_model,

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -556,6 +556,8 @@ def get_halpha_loss(
     )
 
     sig = jnp.diff(lg_halpha_Lbin_edges) / 2
+    sig = sig.reshape(sig.size, 1)
+    print("sig.shape:{}", sig.shape)
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -27,7 +27,6 @@ from jax import jit as jjit
 from jax import lax
 from jax import random as jran
 from jax import value_and_grad, vmap
-from jax.debug import print
 from jax.example_libraries import optimizers as jax_opt
 from jax.flatten_util import ravel_pytree
 
@@ -555,12 +554,9 @@ def get_halpha_loss(
 
     sig = jnp.diff(lg_halpha_Lbin_edges) / 2
     sig = sig.reshape(sig.size, 1)
-    print("lg_halpha_Lbin_edges:{}", lg_halpha_Lbin_edges)
-    print("sig:{}", sig)
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )
-    print("halpha_N:{}", halpha_N)
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
     halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
 
@@ -670,7 +666,6 @@ def _loss_kern(
         frac_cat,
     )
     loss = _mse_w(lg_n_model, lg_n_target[0], lg_n_target[1], lg_n_thresh)
-    print("loss:{}", loss)
 
     if lg_halpha_LF_target is not None:
         halpha_lc_mah_params = DiffmahParams(*halpha_lc_mah_params)
@@ -694,7 +689,6 @@ def _loss_kern(
             cosmo_params,
             fb,
         )
-        print("halpha_loss:{}", get_halpha_loss(*halpha_loss_args))
         loss += get_halpha_loss(*halpha_loss_args)
 
     return loss

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -555,7 +555,7 @@ def get_halpha_loss(
         fb,
     )
 
-    sig = jnp.mean(jnp.diff(lg_halpha_Lbin_edges)) / 2
+    sig = jnp.diff(lg_halpha_Lbin_edges) / 2
     _, halpha_N = emline_luminosity.get_emline_luminosity_func(
         L_halpha_cgs, lc_nhalos, sig=sig, lgL_bin_edges=lg_halpha_Lbin_edges
     )

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -44,6 +44,8 @@ u_zero_ssp_err_pop_theta, u_zero_ssp_err_pop_unravel = ravel_pytree(
     ZERO_SSPERR_U_PARAMS
 )
 
+HALPHA_WAVE_AA = 6565.09893918  # halpha_line_center_c3k
+
 # used for fisher analysis
 # @jjit
 # def _mse_w(lg_n_pred, lg_n_target, lg_n_target_err, lg_n_thresh):
@@ -524,7 +526,6 @@ def get_halpha_loss(
     lc_z_obs,
     lc_t_obs,
     lc_mah_params,
-    lc_logmp0,
     lc_nhalos,
     lc_vol_mpc3,
     t_table,
@@ -547,7 +548,7 @@ def get_halpha_loss(
         scatter_params,
         t_table,
         ssp_data,
-        halpha_wave_aa,
+        HALPHA_WAVE_AA,
         ssp_halpha_luminosity,
         cosmo_params,
         fb,
@@ -607,7 +608,6 @@ def _loss_kern(
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
-    halpha_lc_logmp0=None,
     halpha_lc_nhalos=None,
     halpha_lc_vol_mpc3=None,
 ):
@@ -681,7 +681,6 @@ def _loss_kern(
             halpha_lc_z_obs,
             halpha_lc_t_obs,
             halpha_lc_mah_params,
-            halpha_lc_logmp0,
             halpha_lc_nhalos,
             halpha_lc_vol_mpc3,
             t_table,
@@ -736,7 +735,6 @@ def fit_n(
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
-    halpha_lc_logmp0=None,
     halpha_lc_nhalos=None,
     halpha_lc_vol_mpc3=None,
 ):
@@ -774,7 +772,6 @@ def fit_n(
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,
-        halpha_lc_logmp0,
         halpha_lc_nhalos,
         halpha_lc_vol_mpc3,
     )
@@ -820,7 +817,6 @@ _L = (
     None,
     None,
     None,
-    0,
     0,
     0,
     0,
@@ -881,7 +877,6 @@ def fit_n_multi_z(
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
-    halpha_lc_logmp0=None,
     halpha_lc_nhalos=None,
     halpha_lc_vol_mpc3=None,
 ):
@@ -919,7 +914,6 @@ def fit_n_multi_z(
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,
-        halpha_lc_logmp0,
         halpha_lc_nhalos,
         halpha_lc_vol_mpc3,
     )
@@ -1071,7 +1065,6 @@ def _loss_kern_w_nbs(
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
-    halpha_lc_logmp0=None,
     halpha_lc_nhalos=None,
     halpha_lc_vol_mpc3=None,
 ):
@@ -1181,7 +1174,6 @@ def _loss_kern_w_nbs(
             halpha_lc_z_obs,
             halpha_lc_t_obs,
             halpha_lc_mah_params,
-            halpha_lc_logmp0,
             halpha_lc_nhalos,
             halpha_lc_vol_mpc3,
             t_table,
@@ -1235,7 +1227,6 @@ _L_w_nbs = (
     None,
     None,
     None,
-    0,
     0,
     0,
     0,
@@ -1306,7 +1297,6 @@ def fit_n_w_nbs_multi_z(
     halpha_lc_z_obs=None,
     halpha_lc_t_obs=None,
     halpha_lc_mah_params=None,
-    halpha_lc_logmp0=None,
     halpha_lc_nhalos=None,
     halpha_lc_vol_mpc3=None,
 ):
@@ -1354,7 +1344,6 @@ def fit_n_w_nbs_multi_z(
         halpha_lc_z_obs,
         halpha_lc_t_obs,
         halpha_lc_mah_params,
-        halpha_lc_logmp0,
         halpha_lc_nhalos,
         halpha_lc_vol_mpc3,
     )

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -8,6 +8,7 @@ jax.config.update("jax_debug_infs", True)
 from functools import partial
 
 import jax.numpy as jnp
+from diffmah.defaults import DiffmahParams
 from diffsky.experimental import mc_lightcone_halos as mclh
 from diffsky.mass_functions import mc_hosts
 from diffsky.param_utils.spspop_param_utils import (
@@ -537,7 +538,6 @@ def get_halpha_loss(
     cosmo_params,
     fb,
 ):
-    print("lc_mah_params.shape:{}", lc_mah_params.shape)
     L_halpha_cgs, _ = emline_luminosity.compute_emline_luminosity(
         ran_key,
         lc_z_obs,
@@ -673,6 +673,7 @@ def _loss_kern(
     loss = _mse_w(lg_n_model, lg_n_target[0], lg_n_target[1], lg_n_thresh)
 
     if lg_halpha_LF_target is not None:
+        halpha_lc_mah_params = DiffmahParams(*halpha_lc_mah_params)
         halpha_loss_args = (
             diffstarpop_params,
             ran_key,
@@ -1166,6 +1167,7 @@ def _loss_kern_w_nbs(
     loss += jnp.sum(nb_losses)
 
     if lg_halpha_LF_target is not None:
+        halpha_lc_mah_params = DiffmahParams(*halpha_lc_mah_params)
         halpha_loss_args = (
             diffstarpop_params,
             ran_key,

--- a/diffhtwo/experimental/n_mag_opt.py
+++ b/diffhtwo/experimental/n_mag_opt.py
@@ -35,7 +35,7 @@ from diffhtwo.experimental.utils import safe_log10
 
 from . import diffstarpop_halpha as dpop_halpha
 from . import emline_luminosity
-from .n_mag import n_mag_kern, n_mag_kern_1d, n_mag_kern_nocolor
+from .n_mag import N_0, N_FLOOR, n_mag_kern, n_mag_kern_1d, n_mag_kern_nocolor
 
 u_diffstarpop_theta_default, u_diffstarpop_unravel = ravel_pytree(
     DEFAULT_DIFFSTARPOP_U_PARAMS
@@ -263,10 +263,8 @@ def _loss_kern_1d(
             + halpha_lf_weighted_bursty_ms
         )
         # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
-        N_0 = 1e-12
-        N_floor = 0.5
         halpha_lf_weighted_composite = jnp.where(
-            halpha_lf_weighted_composite > N_floor, halpha_lf_weighted_composite, N_0
+            halpha_lf_weighted_composite > N_FLOOR, halpha_lf_weighted_composite, N_0
         )
 
         lg_halpha_LF_model = jnp.log10(
@@ -562,9 +560,7 @@ def get_halpha_loss(
     )
 
     # take care of bins with low/zero number counts in a similar way to n_mag.get_n_data_err(), using same N_floor and N_0:
-    N_0 = 1e-12
-    N_floor = 0.5
-    halpha_N = jnp.where(halpha_N > N_floor, halpha_N, N_0)
+    halpha_N = jnp.where(halpha_N > N_FLOOR, halpha_N, N_0)
 
     lg_halpha_LF_model = jnp.log10(halpha_N / lc_vol_mpc3)
 

--- a/diffhtwo/experimental/precompute_line_luminosity_kern.py
+++ b/diffhtwo/experimental/precompute_line_luminosity_kern.py
@@ -121,7 +121,7 @@ def _get_integrated_luminosity(wave, sed):
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
 
-    integrated_luminosity = np.trapezoid(sed, freq)  # [Lsun/Msun]
+    integrated_luminosity = jnp.trapezoid(sed, freq)  # [Lsun/Msun]
 
     return integrated_luminosity
 

--- a/diffhtwo/experimental/tests/test_n_mag_multi_z.py
+++ b/diffhtwo/experimental/tests/test_n_mag_multi_z.py
@@ -250,7 +250,6 @@ loss_multi_z = n_mag_opt._loss_kern_multi_z(
     None,
     None,
     None,
-    None,
 )
 
 for zbin in range(0, len(zbins)):

--- a/diffhtwo/experimental/tests/test_n_mag_multi_z.py
+++ b/diffhtwo/experimental/tests/test_n_mag_multi_z.py
@@ -251,8 +251,6 @@ loss_multi_z = n_mag_opt._loss_kern_multi_z(
     None,
     None,
     None,
-    None,
-    None,
 )
 
 for zbin in range(0, len(zbins)):

--- a/diffhtwo/experimental/tests/test_n_mag_opt.py
+++ b/diffhtwo/experimental/tests/test_n_mag_opt.py
@@ -218,7 +218,6 @@ halpha_loss = n_mag_opt.get_halpha_loss(
     lc_halopop["z_obs"],
     lc_halopop["t_obs"],
     lc_halopop["mah_params"],
-    lc_halopop["logmp0"],
     lc_halopop["nhalos"],
     lc_vol,
     t_table,

--- a/diffhtwo/experimental/tests/test_n_mag_opt.py
+++ b/diffhtwo/experimental/tests/test_n_mag_opt.py
@@ -215,8 +215,6 @@ halpha_loss = n_mag_opt.get_halpha_loss(
     lg_halpha_LF_target,
     lg_halpha_Lbin_edges,
     lg_n_thresh,
-    zmin,
-    zmax,
     lc_halopop["z_obs"],
     lc_halopop["t_obs"],
     lc_halopop["mah_params"],

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -133,7 +133,7 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     L_UV_unit = _calc_galpop_rest_uv_luminosity(
-        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans, dust=dust
+        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans, dust
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -46,9 +46,9 @@ def compute_uv_luminosity(
     scatter_params,
     t_table,
     ssp_data,
-    lgmet_scatter,
     cosmo_params,
     fb,
+    lgmet_scatter=LGMET_SCATTER,
     n_t_table=mcdw.N_T_TABLE,
 ):
     phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -47,15 +47,20 @@ def _get_integrated_luminosity(wave, sed):
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_data, weights):
+def calc_singlegal_rest_uv_luminosity(ssp_data, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
     """
+
+    n_met, n_age = ssp_weights.shape
+
+    # broadcast ftrans due to dust across metallicity
+    ssp_weights_w_ftrans = ssp_weights * ftrans.reshape(1, n_age)
+
     # get weighted sed
-    n_met, n_ages = weights.shape
     sed_weighted = jnp.sum(
-        ssp_data.ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1)
+        ssp_data.ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
 
     # get integrated uv luminosity within UV tophat window
@@ -70,7 +75,7 @@ def calc_singlegal_rest_uv_luminosity(ssp_data, weights):
     return integrated_uv_luminosity  # [Lsun/Msun]
 
 
-_S = (None, 0)
+_S = (None, 0, 0)
 calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
@@ -116,8 +121,6 @@ def compute_uv_luminosity(
 
     ssp_weights, burst_params, mc_sfh_type = _res
 
-    L_UV_unit = calc_rest_uv_luminosity(ssp_data, ssp_weights)  # [Lsun/Msun]
-
     ftrans_args = (
         spspop_params.dustpop_params,
         UV_WAVELENGTH_AA,
@@ -130,17 +133,20 @@ def compute_uv_luminosity(
         phot_randoms.uran_funo,
         scatter_params,
     )
-    _res_dust = calc_dust_ftrans_vmap(
-        *ftrans_args
-    )  # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
-    frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
+
+    # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
+    _res_dust = calc_dust_ftrans_vmap(*ftrans_args)
+
+    # frac_trans.shape = (n_gals, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
+    frac_trans = _res_dust[1]
+
+    L_UV_unit = calc_rest_uv_luminosity(
+        ssp_data, ssp_weights, frac_trans
+    )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs
 
-    print("frac_trans.shape:{}", frac_trans.shape)
-    print("L_UV_unit.shape:{}", L_UV_unit.shape)
-    print("_mstar.shape:{}", _mstar.shape)
-    # L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]
+    L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    # return L_UV_cgs
+    return L_UV_cgs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -51,7 +51,7 @@ def _calc_singlegal_rest_uv_luminosity(
     if dust is True:
         # broadcast ftrans due to dust across metallicity
         ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
-        print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
+        print("jnp.sum(ssp_weights_w_dust):{}", jnp.sum(ssp_weights))
 
     # get weighted sed
     sed_weighted = jnp.sum(
@@ -142,4 +142,4 @@ def compute_uv_luminosity(
 
     L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs
+    return L_UV_cgs, frac_trans

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -1,0 +1,99 @@
+# import jax.numpy as jnp
+from diffsky.dustpop import tw_dustpop_mono_noise
+from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
+from diffsky.experimental.kernels import mc_phot_kernels as mcpk
+from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
+from jax import jit as jjit
+from jax import vmap
+from jax.debug import print
+
+LGMET_SCATTER = 0.2
+
+# rest UV wavelength for continuum calculation in Angstroms
+UV_WAVELENGTH_AA = 1500
+
+_D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
+calc_dust_ftrans_vmap = jjit(
+    vmap(
+        tw_dustpop_mono_noise.calc_ftrans_singlegal_singlewave_from_dustpop_params,
+        in_axes=_D,
+    )
+)
+
+
+# @jjit
+# def calc_singlegal_rest_uv_luminosity(ssp_flux, weights):
+#     n_met, n_ages = weights.shape
+#     sed_unit_mstar = jnp.sum(
+#         ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1)
+#     )
+#     return sed_unit_mstar
+
+
+# _S = (None, 0)
+# calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
+
+
+@jjit
+def compute_uv_luminosity(
+    ran_key,
+    z_obs,
+    t_obs,
+    mah_params,
+    diffstarpop_params,
+    spspop_params,
+    mzr_params,
+    scatter_params,
+    t_table,
+    ssp_data,
+    lgmet_scatter,
+    cosmo_params,
+    fb,
+    n_t_table=mcdw.N_T_TABLE,
+):
+    phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
+        ran_key, diffstarpop_params, mah_params, cosmo_params
+    )
+
+    t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
+        mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
+    )
+
+    age_weights_smooth, lgmet_weights = sspwk.get_smooth_ssp_weights(
+        t_table, sfh_table, logsm_obs, ssp_data, t_obs, mzr_params, LGMET_SCATTER
+    )
+
+    _res = sspwk.compute_burstiness(
+        phot_randoms.uran_pburst,
+        phot_randoms.mc_is_q,
+        logsm_obs,
+        logssfr_obs,
+        age_weights_smooth,
+        lgmet_weights,
+        ssp_data,
+        spspop_params.burstpop_params,
+    )
+
+    ssp_weights, burst_params, mc_sfh_type = _res
+
+    print("ssp_weights.shape:{}", ssp_weights.shape)
+
+    # L_UV = calc_rest_uv_luminosity(ssp_data.ssp_flux, ssp_weights)
+
+    # ftrans_args = (
+    #     spspop_params.dustpop_params,
+    #     UV_WAVELENGTH_AA,
+    #     logsm_obs,
+    #     logssfr_obs,
+    #     z_obs,
+    #     ssp_data.ssp_lg_age_gyr,
+    #     phot_randoms.uran_av,
+    #     phot_randoms.uran_delta,
+    #     phot_randoms.uran_funo,
+    #     scatter_params,
+    # )
+    # _res_dust = calc_dust_ftrans_vmap(
+    #     *ftrans_args
+    # )  # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
+    # frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
+    # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -137,11 +137,11 @@ def compute_uv_luminosity(
     uv_tophat = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
         ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
     )
-    ssp_wave = ssp_data.ssp_wave[uv_tophat]
-    ssp_flux = ssp_data.ssp_flux[uv_tophat]
+    ssp_wave_masked = jnp.where(uv_tophat, ssp_data.ssp_wave, 0.0)
+    ssp_flux_masked = jnp.where(uv_tophat, ssp_data.ssp_flux, 0.0)
 
     L_UV_unit = calc_rest_uv_luminosity(
-        ssp_wave, ssp_flux, ssp_weights, frac_trans
+        ssp_wave_masked, ssp_flux_masked, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -147,4 +147,12 @@ def compute_uv_luminosity(
 
     L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs
+    # no dust
+    frac_trans_nodust = jnp.ones_like(frac_trans)
+    L_UV_unit_nodust = _calc_galpop_rest_uv_luminosity(
+        precomputed_uv_luminosity, ssp_weights, frac_trans_nodust
+    )  # [Lsun/Msun]
+
+    L_UV_cgs_nodust = L_UV_unit_nodust * L_SUN_CGS * _mstar  # [erg/s]
+
+    return L_UV_cgs, L_UV_cgs_nodust

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -26,6 +26,12 @@ C = 299792458.0
 UV_WAVELENGTH_AA = 1500 + 1.713
 UV_FREQUENCY_HZ = C / (UV_WAVELENGTH_AA * 1e-10)
 
+_A = (None, None, 0)
+interp_vmap = jjit(vmap(jnp.interp, in_axes=_A))
+
+_B = (None, None, 1)
+interp_vmap2 = jjit(vmap(interp_vmap, in_axes=_B))
+
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
 _calc_dust_ftrans_vmap = jjit(
     vmap(
@@ -36,38 +42,67 @@ _calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def _calc_singlegal_rest_uv_luminosity(
-    ssp_wave, ssp_flux, ssp_weights, ftrans, dust=True
-):
+def precompute_uv_luminosity(ssp_data):
+    uv_luminosity_per_hz = interp_vmap2(
+        UV_WAVELENGTH_AA, ssp_data.ssp_wave, ssp_data.ssp_flux
+    ).T
+    # get uv_luminosity in units of Lsun/Msun
+    uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz
+    return uv_luminosity
+
+
+# @jjit
+# def _calc_singlegal_rest_uv_luminosity(
+#     ssp_wave, ssp_flux, ssp_weights, ftrans, dust=True
+# ):
+#     """
+#     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
+#     ssp_weights: combined age metallicity weights with shape (n_met, n_age)
+#     """
+
+#     n_met, n_age = ssp_weights.shape
+
+#     # print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
+
+#     # if dust is True:
+#     #     # broadcast ftrans due to dust across metallicity
+#     #     ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
+#     #     print("jnp.sum(ssp_weights_w_dust):{}", jnp.sum(ssp_weights))
+
+#     # get weighted sed
+#     sed_weighted = jnp.sum(
+#         ssp_flux * ssp_weights.reshape((n_met, n_age, 1)), axis=(0, 1)
+#     )
+
+#     # uv_luminosity in units of Lsun/Msun/Hz
+#     uv_luminosity_per_hz = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
+
+#     # get uv_luminosity in units of Lsun/Msun
+#     uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz * ftrans
+
+#     return uv_luminosity
+
+
+@jjit
+def _calc_singlegal_rest_uv_luminosity(precomputed_uv_luminosity, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
-    weights: combined age metallicity weights with shape (n_met, n_age)
+    ssp_weights: combined age metallicity weights with shape (n_met, n_age)
     """
 
     n_met, n_age = ssp_weights.shape
 
-    print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
+    # broadcast ftrans due to dust across metallicity
+    ftrans = ftrans.reshape(1, n_age)
 
-    if dust is True:
-        # broadcast ftrans due to dust across metallicity
-        ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
-        print("jnp.sum(ssp_weights_w_dust):{}", jnp.sum(ssp_weights))
+    # get ssp weighted uv luminosity with ftrans due to dust incorporated. Units: [Lsun/Msun]
+    integrand = precomputed_uv_luminosity * ssp_weights * ftrans
+    uv_luminosity_weighted_w_dust = jnp.sum(integrand, axis=(0, 1))
 
-    # get weighted sed
-    sed_weighted = jnp.sum(
-        ssp_flux * ssp_weights.reshape((n_met, n_age, 1)), axis=(0, 1)
-    )
-
-    # uv_luminosity in units of Lsun/Msun/Hz
-    uv_luminosity_per_hz = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
-
-    # get uv_luminosity in units of Lsun/Msun
-    uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz
-
-    return uv_luminosity
+    return uv_luminosity_weighted_w_dust
 
 
-_S = (None, None, 0, 0, None)
+_S = (None, 0, 0)
 _calc_galpop_rest_uv_luminosity = vmap(_calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
@@ -83,6 +118,7 @@ def compute_uv_luminosity(
     scatter_params,
     t_table,
     ssp_data,
+    precomputed_uv_luminosity,
     cosmo_params,
     fb,
     lgmet_scatter=LGMET_SCATTER,
@@ -113,6 +149,7 @@ def compute_uv_luminosity(
     )
 
     ssp_weights, burst_params, mc_sfh_type = _res
+    print("ssp_weights.shape:{}", ssp_weights.shape)
 
     ftrans_args = (
         spspop_params.dustpop_params,
@@ -135,7 +172,7 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     L_UV_unit = _calc_galpop_rest_uv_luminosity(
-        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans, dust
+        precomputed_uv_luminosity, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -67,7 +67,6 @@ def _get_integrated_luminosity(wave, sed, mask):
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
     mask = jnp.flip(mask)
-    print("jnp.sum(sed):{}", jnp.sum(sed))
 
     integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
 
@@ -90,8 +89,6 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftr
     sed_weighted = jnp.sum(
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
-    print("ssp_wave.shape:{}", ssp_wave.shape)
-    print("sed_weighted.shape:{}", sed_weighted.shape)
 
     integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
     return integrated_uv_luminosity  # [Lsun/Msun]

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -24,7 +24,7 @@ L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
 C = 299792458.0
 
 # rest UV wavelength for continuum calculation in Angstroms
-UV_WAVELENGTH_AA = 1500
+UV_WAVELENGTH_AA = 1500 + 1.713
 UV_FREQUENCY_HZ = C / (UV_WAVELENGTH_AA * 1e-10)
 
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -47,7 +47,7 @@ def _get_integrated_luminosity(wave, sed):
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_data, ssp_weights, ftrans):
+def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
@@ -60,22 +60,14 @@ def calc_singlegal_rest_uv_luminosity(ssp_data, ssp_weights, ftrans):
 
     # get weighted sed
     sed_weighted = jnp.sum(
-        ssp_data.ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
+        ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
 
-    # get integrated uv luminosity within UV tophat window
-    uv_tophat = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
-        ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
-    )
-    clipped_wave = jnp.where(uv_tophat, ssp_data.ssp_wave, 0.0)
-    clipped_sed_weighted = jnp.where(uv_tophat, sed_weighted, 0.0)
-    integrated_uv_luminosity = _get_integrated_luminosity(
-        clipped_wave, clipped_sed_weighted
-    )
+    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted)
     return integrated_uv_luminosity  # [Lsun/Msun]
 
 
-_S = (None, 0, 0)
+_S = (None, None, 0, 0)
 calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
@@ -141,8 +133,15 @@ def compute_uv_luminosity(
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
     frac_trans = _res_dust[1]
 
+    # get integrated uv luminosity within UV tophat window
+    uv_tophat = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
+        ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
+    )
+    ssp_wave = ssp_data.ssp_wave[uv_tophat]
+    ssp_flux = ssp_data.ssp_flux[uv_tophat]
+
     L_UV_unit = calc_rest_uv_luminosity(
-        ssp_data, ssp_weights, frac_trans
+        ssp_wave, ssp_flux, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -138,7 +138,7 @@ def compute_uv_luminosity(
 
     print("frac_trans.shape:{}", frac_trans.shape)
 
-    _mstar = 10**logsm_obs
-    L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]
+    # _mstar = 10**logsm_obs
+    # L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs
+    # return L_UV_cgs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -90,6 +90,8 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftr
     sed_weighted = jnp.sum(
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
+    print("ssp_wave.shape:{}", ssp_wave.shape)
+    print("sed_weighted.shape:{}", sed_weighted.shape)
 
     integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
     return integrated_uv_luminosity  # [Lsun/Msun]
@@ -162,8 +164,9 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     # get integrated uv luminosity within UV tophat window
-    uv_tophat_mask = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
-        ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
+    d_UV_AA = 100 / 2
+    uv_tophat_mask = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - d_UV_AA) & (
+        ssp_data.ssp_wave < UV_WAVELENGTH_AA + d_UV_AA
     )
 
     L_UV_unit = calc_rest_uv_luminosity(

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -66,8 +66,7 @@ def _get_integrated_luminosity(wave, sed, mask):
     """
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
-    print("freq:{}", freq)
-    print("sed:{}", sed)
+    mask = jnp.flip(mask)
 
     integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -12,8 +12,7 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-
-# from jax.debug import print
+from jax.debug import print
 
 LGMET_SCATTER = 0.2
 
@@ -47,9 +46,12 @@ def _calc_singlegal_rest_uv_luminosity(
 
     n_met, n_age = ssp_weights.shape
 
+    print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
+
     if dust is True:
         # broadcast ftrans due to dust across metallicity
         ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
+        print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
 
     # get weighted sed
     sed_weighted = jnp.sum(

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -60,10 +60,10 @@ def calc_singlegal_rest_uv_luminosity(ssp_data, weights):
     )
 
     # get integrated uv luminosity within UV tophat window
-    uv_tophat = (ssp_data.wave > UV_WAVELENGTH_AA - 50) & (
-        ssp_data.wave < UV_WAVELENGTH_AA - 50
+    uv_tophat = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
+        ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
     )
-    clipped_wave = jnp.where(uv_tophat, ssp_data.wave, 0.0)
+    clipped_wave = jnp.where(uv_tophat, ssp_data.ssp_wave, 0.0)
     clipped_sed_weighted = jnp.where(uv_tophat, sed_weighted, 0.0)
     integrated_uv_luminosity = _get_integrated_luminosity(
         clipped_wave, clipped_sed_weighted

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -28,7 +28,7 @@ UV_WAVELENGTH_AA = 1500 + 1.713
 UV_FREQUENCY_HZ = C / (UV_WAVELENGTH_AA * 1e-10)
 
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
-calc_dust_ftrans_vmap = jjit(
+_calc_dust_ftrans_vmap = jjit(
     vmap(
         tw_dustpop_mono_noise.calc_ftrans_singlegal_singlewave_from_dustpop_params,
         in_axes=_D,
@@ -37,7 +37,7 @@ calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
+def _calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
@@ -64,7 +64,7 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
 
 
 _S = (None, None, 0, 0)
-calc_galpop_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
+_calc_galpop_rest_uv_luminosity = vmap(_calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
 @jjit
@@ -123,13 +123,13 @@ def compute_uv_luminosity(
     )
 
     # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
-    _res_dust = calc_dust_ftrans_vmap(*ftrans_args)
+    _res_dust = _calc_dust_ftrans_vmap(*ftrans_args)
 
     # frac_trans.shape = (n_gals, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
     frac_trans = _res_dust[1]
 
-    L_UV_unit = calc_galpop_rest_uv_luminosity(
+    L_UV_unit = _calc_galpop_rest_uv_luminosity(
         ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -37,44 +37,6 @@ calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def masked_trapz(y, x, mask):
-    """
-    y: values (e.g. sed)
-    x: grid (e.g. freq)
-    mask: boolean array selecting window
-    """
-
-    # trapezoid segments
-    dx = x[1:] - x[:-1]
-    avg = 0.5 * (y[1:] + y[:-1])
-
-    # keep segments that overlap the mask
-    seg_on = mask[:-1] | mask[1:]
-
-    return jnp.sum(jnp.where(seg_on, avg * dx, 0.0))
-
-
-@jjit
-def _get_integrated_luminosity(wave, sed, mask):
-    """
-    Parameters:
-            wave - wavelength array in units of Angstrom
-            sed - [Lsun/Hz/Msun]
-
-    Returns:
-            integrated_luminosity - integrated sed in units of [Lsun/Msun]
-
-    """
-    freq = C / (wave * 1e-10)
-    freq = jnp.flip(freq)
-    mask = jnp.flip(mask)
-
-    integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
-
-    return integrated_luminosity
-
-
-@jjit
 def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
@@ -166,10 +128,6 @@ def compute_uv_luminosity(
     # frac_trans.shape = (n_gals, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
     frac_trans = _res_dust[1]
-
-    # get integrated uv luminosity within UV tophat window
-    # d_UV_AA = 10 / 2
-    # uv_tophat_mask = (ssp_data.ssp_wave > 1200) & (ssp_data.ssp_wave < 3000)
 
     L_UV_unit = calc_galpop_rest_uv_luminosity(
         ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -89,9 +89,10 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftr
     sed_weighted = jnp.sum(
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
+    uv_luminosity = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
 
-    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
-    return integrated_uv_luminosity  # [Lsun/Msun]
+    # integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
+    return uv_luminosity  # [Lsun/Msun]
 
 
 _S = (None, None, None, 0, 0)

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -51,43 +51,12 @@ def precompute_uv_luminosity(ssp_data):
     return uv_luminosity
 
 
-# @jjit
-# def _calc_singlegal_rest_uv_luminosity(
-#     ssp_wave, ssp_flux, ssp_weights, ftrans, dust=True
-# ):
-#     """
-#     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
-#     ssp_weights: combined age metallicity weights with shape (n_met, n_age)
-#     """
-
-#     n_met, n_age = ssp_weights.shape
-
-#     # print("jnp.sum(ssp_weights):{}", jnp.sum(ssp_weights))
-
-#     # if dust is True:
-#     #     # broadcast ftrans due to dust across metallicity
-#     #     ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
-#     #     print("jnp.sum(ssp_weights_w_dust):{}", jnp.sum(ssp_weights))
-
-#     # get weighted sed
-#     sed_weighted = jnp.sum(
-#         ssp_flux * ssp_weights.reshape((n_met, n_age, 1)), axis=(0, 1)
-#     )
-
-#     # uv_luminosity in units of Lsun/Msun/Hz
-#     uv_luminosity_per_hz = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
-
-#     # get uv_luminosity in units of Lsun/Msun
-#     uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz * ftrans
-
-#     return uv_luminosity
-
-
 @jjit
 def _calc_singlegal_rest_uv_luminosity(precomputed_uv_luminosity, ssp_weights, ftrans):
     """
-    ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
-    ssp_weights: combined age metallicity weights with shape (n_met, n_age)
+    precomputed_uv_luminosity: (nmet, nage)
+    ssp_weights: (n_met, n_age)
+    ftrans : (nage,)
     """
 
     n_met, n_age = ssp_weights.shape
@@ -149,7 +118,6 @@ def compute_uv_luminosity(
     )
 
     ssp_weights, burst_params, mc_sfh_type = _res
-    print("ssp_weights.shape:{}", ssp_weights.shape)
 
     ftrans_args = (
         spspop_params.dustpop_params,
@@ -179,4 +147,4 @@ def compute_uv_luminosity(
 
     L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs, frac_trans
+    return L_UV_cgs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -137,4 +137,4 @@ def compute_uv_luminosity(
 
     L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs
+    return L_UV_cgs, frac_trans

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -66,6 +66,8 @@ def _get_integrated_luminosity(wave, sed, mask):
     """
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
+    print("freq:{}", freq)
+    print("sed:{}", sed)
 
     integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -48,16 +48,26 @@ def _get_integrated_luminosity(wave, sed):
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_flux, weights):
+def calc_singlegal_rest_uv_luminosity(ssp_data, weights):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
     """
-    wave = jnp.linspace(UV_WAVELENGTH_AA - 50, UV_WAVELENGTH_AA + 50, 100)
+    # get weighted sed
     n_met, n_ages = weights.shape
+    sed_weighted = jnp.sum(
+        ssp_data.ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1)
+    )
 
-    sed_weighted = jnp.sum(ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1))
-    integrated_uv_luminosity = _get_integrated_luminosity(wave, sed_weighted)
+    # get integrated uv luminosity within UV tophat window
+    uv_tophat = (ssp_data.wave > UV_WAVELENGTH_AA - 50) & (
+        ssp_data.wave < UV_WAVELENGTH_AA - 50
+    )
+    clipped_wave = jnp.where(uv_tophat, ssp_data.wave, 0.0)
+    clipped_sed_weighted = jnp.where(uv_tophat, sed_weighted, 0.0)
+    integrated_uv_luminosity = _get_integrated_luminosity(
+        clipped_wave, clipped_sed_weighted
+    )
     return integrated_uv_luminosity  # [Lsun/Msun]
 
 
@@ -107,7 +117,7 @@ def compute_uv_luminosity(
 
     ssp_weights, burst_params, mc_sfh_type = _res
 
-    L_UV_unit = calc_rest_uv_luminosity(ssp_data.ssp_flux, ssp_weights)  # [Lsun/Msun]
+    L_UV_unit = calc_rest_uv_luminosity(ssp_data, ssp_weights)  # [Lsun/Msun]
 
     ftrans_args = (
         spspop_params.dustpop_params,

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -1,4 +1,4 @@
-# import jax.numpy as jnp
+import jax.numpy as jnp
 from diffsky.dustpop import tw_dustpop_mono_noise
 from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
 from diffsky.experimental.kernels import mc_phot_kernels as mcpk
@@ -7,7 +7,12 @@ from jax import jit as jjit
 from jax import vmap
 from jax.debug import print
 
+from .precompute_line_luminosity_kern import _get_integrated_luminosity
+
 LGMET_SCATTER = 0.2
+
+# copied from astropy.constants.L_sun.cgs.value
+L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
 
 # rest UV wavelength for continuum calculation in Angstroms
 UV_WAVELENGTH_AA = 1500
@@ -21,17 +26,22 @@ calc_dust_ftrans_vmap = jjit(
 )
 
 
-# @jjit
-# def calc_singlegal_rest_uv_luminosity(ssp_flux, weights):
-#     n_met, n_ages = weights.shape
-#     sed_unit_mstar = jnp.sum(
-#         ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1)
-#     )
-#     return sed_unit_mstar
+@jjit
+def calc_singlegal_rest_uv_luminosity(ssp_flux, weights):
+    """
+    ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
+    weights: combined age metallicity weights with shape (n_met, n_age)
+    """
+    wave = jnp.linspace(UV_WAVELENGTH_AA - 50, UV_WAVELENGTH_AA + 50, 100)
+    n_met, n_ages = weights.shape
+
+    sed_weighted = jnp.sum(ssp_flux * weights.reshape((n_met, n_ages, 1)), axis=(0, 1))
+    integrated_uv_luminosity = _get_integrated_luminosity(wave, sed_weighted)
+    return integrated_uv_luminosity  # [Lsun/Msun]
 
 
-# _S = (None, 0)
-# calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
+_S = (None, 0)
+calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
 @jjit
@@ -76,24 +86,27 @@ def compute_uv_luminosity(
 
     ssp_weights, burst_params, mc_sfh_type = _res
 
-    print("ssp_weights.shape:{}", ssp_weights.shape)
+    L_UV_unit = calc_rest_uv_luminosity(ssp_data.ssp_flux, ssp_weights)  # [Lsun/Msun]
 
-    # L_UV = calc_rest_uv_luminosity(ssp_data.ssp_flux, ssp_weights)
-
-    # ftrans_args = (
-    #     spspop_params.dustpop_params,
-    #     UV_WAVELENGTH_AA,
-    #     logsm_obs,
-    #     logssfr_obs,
-    #     z_obs,
-    #     ssp_data.ssp_lg_age_gyr,
-    #     phot_randoms.uran_av,
-    #     phot_randoms.uran_delta,
-    #     phot_randoms.uran_funo,
-    #     scatter_params,
-    # )
-    # _res_dust = calc_dust_ftrans_vmap(
-    #     *ftrans_args
-    # )  # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
-    # frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
+    ftrans_args = (
+        spspop_params.dustpop_params,
+        UV_WAVELENGTH_AA,
+        logsm_obs,
+        logssfr_obs,
+        z_obs,
+        ssp_data.ssp_lg_age_gyr,
+        phot_randoms.uran_av,
+        phot_randoms.uran_delta,
+        phot_randoms.uran_funo,
+        scatter_params,
+    )
+    _res_dust = calc_dust_ftrans_vmap(
+        *ftrans_args
+    )  # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
+    frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
+
+    _mstar = 10**logsm_obs
+    L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]
+
+    return L_UV_cgs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -67,6 +67,7 @@ def _get_integrated_luminosity(wave, sed, mask):
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
     mask = jnp.flip(mask)
+    print("jnp.sum(sed):{}", jnp.sum(sed))
 
     integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -37,7 +37,9 @@ _calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def _calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
+def _calc_singlegal_rest_uv_luminosity(
+    ssp_wave, ssp_flux, ssp_weights, ftrans, dust=True
+):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
@@ -45,12 +47,13 @@ def _calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
 
     n_met, n_age = ssp_weights.shape
 
-    # broadcast ftrans due to dust across metallicity
-    ssp_weights_w_ftrans = ssp_weights * ftrans.reshape(1, n_age)
+    if dust is True:
+        # broadcast ftrans due to dust across metallicity
+        ssp_weights = ssp_weights * ftrans.reshape(1, n_age)
 
     # get weighted sed
     sed_weighted = jnp.sum(
-        ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
+        ssp_flux * ssp_weights.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
 
     # uv_luminosity in units of Lsun/Msun/Hz
@@ -59,11 +62,10 @@ def _calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
     # get uv_luminosity in units of Lsun/Msun
     uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz
 
-    # integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
     return uv_luminosity
 
 
-_S = (None, None, 0, 0)
+_S = (None, None, 0, 0, None)
 _calc_galpop_rest_uv_luminosity = vmap(_calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
@@ -83,6 +85,7 @@ def compute_uv_luminosity(
     fb,
     lgmet_scatter=LGMET_SCATTER,
     n_t_table=mcdw.N_T_TABLE,
+    dust=True,
 ):
     phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
         ran_key, diffstarpop_params, mah_params, cosmo_params
@@ -130,7 +133,7 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     L_UV_unit = _calc_galpop_rest_uv_luminosity(
-        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans
+        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans, dust=dust
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -1,3 +1,10 @@
+# flake8: noqa: E402
+""" """
+import jax
+
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_debug_nans", True)
+jax.config.update("jax_debug_infs", True)
 import jax.numpy as jnp
 from diffsky.dustpop import tw_dustpop_mono_noise
 from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
@@ -5,7 +12,8 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-from jax.debug import print
+
+# from jax.debug import print
 
 LGMET_SCATTER = 0.2
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -161,7 +161,7 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     # get integrated uv luminosity within UV tophat window
-    d_UV_AA = 100 / 2
+    d_UV_AA = 10 / 2
     uv_tophat_mask = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - d_UV_AA) & (
         ssp_data.ssp_wave < UV_WAVELENGTH_AA + d_UV_AA
     )

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -5,14 +5,16 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-from jax.debug import print
 
-from .precompute_line_luminosity_kern import _get_integrated_luminosity
+# from jax.debug import print
 
 LGMET_SCATTER = 0.2
 
 # copied from astropy.constants.L_sun.cgs.value
 L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
+
+# copied from astropy.constants.c.value in m/s
+C = 299792458.0
 
 # rest UV wavelength for continuum calculation in Angstroms
 UV_WAVELENGTH_AA = 1500
@@ -24,6 +26,25 @@ calc_dust_ftrans_vmap = jjit(
         in_axes=_D,
     )
 )
+
+
+@jjit
+def _get_integrated_luminosity(wave, sed):
+    """
+    Parameters:
+            wave - wavelength array in units of Angstrom
+            sed - [Lsun/Hz/Msun]
+
+    Returns:
+            integrated_luminosity - integrated sed in units of [Lsun/Msun]
+
+    """
+    freq = C / (wave * 1e-10)
+    freq = jnp.flip(freq)
+
+    integrated_luminosity = jnp.trapezoid(sed, freq)  # [Lsun/Msun]
+
+    return integrated_luminosity
 
 
 @jjit

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -25,6 +25,7 @@ C = 299792458.0
 
 # rest UV wavelength for continuum calculation in Angstroms
 UV_WAVELENGTH_AA = 1500
+UV_FREQUENCY_HZ = C / (UV_WAVELENGTH_AA * 1e-10)
 
 _D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
 calc_dust_ftrans_vmap = jjit(
@@ -74,7 +75,7 @@ def _get_integrated_luminosity(wave, sed, mask):
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftrans):
+def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
@@ -90,12 +91,18 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftr
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
 
-    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
-    return integrated_uv_luminosity  # [Lsun/Msun]
+    # uv_luminosity in units of Lsun/Msun/Hz
+    uv_luminosity_per_hz = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
+
+    # get uv_luminosity in units of Lsun/Msun
+    uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz
+
+    # integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
+    return uv_luminosity
 
 
-_S = (None, None, None, 0, 0)
-calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
+_S = (None, None, 0, 0)
+calc_galpop_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
 @jjit
@@ -162,10 +169,10 @@ def compute_uv_luminosity(
 
     # get integrated uv luminosity within UV tophat window
     # d_UV_AA = 10 / 2
-    uv_tophat_mask = (ssp_data.ssp_wave > 1200) & (ssp_data.ssp_wave < 3000)
+    # uv_tophat_mask = (ssp_data.ssp_wave > 1200) & (ssp_data.ssp_wave < 3000)
 
-    L_UV_unit = calc_rest_uv_luminosity(
-        ssp_data.ssp_wave, ssp_data.ssp_flux, uv_tophat_mask, ssp_weights, frac_trans
+    L_UV_unit = calc_galpop_rest_uv_luminosity(
+        ssp_data.ssp_wave, ssp_data.ssp_flux, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -36,6 +36,24 @@ calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
+def masked_trapz(y, x, mask):
+    """
+    y: values (e.g. sed)
+    x: grid (e.g. freq)
+    mask: boolean array selecting window
+    """
+
+    # trapezoid segments
+    dx = x[1:] - x[:-1]
+    avg = 0.5 * (y[1:] + y[:-1])
+
+    # keep segments that overlap the mask
+    seg_on = mask[:-1] | mask[1:]
+
+    return jnp.sum(jnp.where(seg_on, avg * dx, 0.0))
+
+
+@jjit
 def _get_integrated_luminosity(wave, sed, mask):
     """
     Parameters:
@@ -49,7 +67,7 @@ def _get_integrated_luminosity(wave, sed, mask):
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
 
-    integrated_luminosity = jnp.trapezoid(sed[mask], freq[mask])  # [Lsun/Msun]
+    integrated_luminosity = masked_trapz(sed, freq, mask)  # [Lsun/Msun]
 
     return integrated_luminosity
 

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -136,9 +136,11 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
 
-    print("frac_trans.shape:{}", frac_trans.shape)
+    _mstar = 10**logsm_obs
 
-    # _mstar = 10**logsm_obs
+    print("frac_trans.shape:{}", frac_trans.shape)
+    print("L_UV_unit.shape:{}", L_UV_unit.shape)
+    print("_mstar.shape:{}", _mstar.shape)
     # L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]
 
     # return L_UV_cgs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -36,7 +36,7 @@ calc_dust_ftrans_vmap = jjit(
 
 
 @jjit
-def _get_integrated_luminosity(wave, sed):
+def _get_integrated_luminosity(wave, sed, mask):
     """
     Parameters:
             wave - wavelength array in units of Angstrom
@@ -49,13 +49,13 @@ def _get_integrated_luminosity(wave, sed):
     freq = C / (wave * 1e-10)
     freq = jnp.flip(freq)
 
-    integrated_luminosity = jnp.trapezoid(sed, freq)  # [Lsun/Msun]
+    integrated_luminosity = jnp.trapezoid(sed[mask], freq[mask])  # [Lsun/Msun]
 
     return integrated_luminosity
 
 
 @jjit
-def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
+def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftrans):
     """
     ssp_flux: ssp flux from ssp_data in default units of Lsun/Hz/Msun
     weights: combined age metallicity weights with shape (n_met, n_age)
@@ -71,11 +71,11 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, ssp_weights, ftrans):
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
 
-    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted)
+    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
     return integrated_uv_luminosity  # [Lsun/Msun]
 
 
-_S = (None, None, 0, 0)
+_S = (None, None, None, 0, 0)
 calc_rest_uv_luminosity = vmap(calc_singlegal_rest_uv_luminosity, in_axes=_S)
 
 
@@ -142,14 +142,12 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     # get integrated uv luminosity within UV tophat window
-    uv_tophat = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
+    uv_tophat_mask = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - 50) & (
         ssp_data.ssp_wave < UV_WAVELENGTH_AA - 50
     )
-    ssp_wave_masked = jnp.where(uv_tophat, ssp_data.ssp_wave, 0.0)
-    ssp_flux_masked = jnp.where(uv_tophat, ssp_data.ssp_flux, 0.0)
 
     L_UV_unit = calc_rest_uv_luminosity(
-        ssp_wave_masked, ssp_flux_masked, ssp_weights, frac_trans
+        ssp_data.ssp_wave, ssp_data.ssp_flux, uv_tophat_mask, ssp_weights, frac_trans
     )  # [Lsun/Msun]
 
     _mstar = 10**logsm_obs

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -89,10 +89,9 @@ def calc_singlegal_rest_uv_luminosity(ssp_wave, ssp_flux, mask, ssp_weights, ftr
     sed_weighted = jnp.sum(
         ssp_flux * ssp_weights_w_ftrans.reshape((n_met, n_age, 1)), axis=(0, 1)
     )
-    uv_luminosity = jnp.interp(UV_WAVELENGTH_AA, ssp_wave, sed_weighted)
 
-    # integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
-    return uv_luminosity  # [Lsun/Msun]
+    integrated_uv_luminosity = _get_integrated_luminosity(ssp_wave, sed_weighted, mask)
+    return integrated_uv_luminosity  # [Lsun/Msun]
 
 
 _S = (None, None, None, 0, 0)
@@ -162,10 +161,8 @@ def compute_uv_luminosity(
     frac_trans = _res_dust[1]
 
     # get integrated uv luminosity within UV tophat window
-    d_UV_AA = 10 / 2
-    uv_tophat_mask = (ssp_data.ssp_wave > UV_WAVELENGTH_AA - d_UV_AA) & (
-        ssp_data.ssp_wave < UV_WAVELENGTH_AA + d_UV_AA
-    )
+    # d_UV_AA = 10 / 2
+    uv_tophat_mask = (ssp_data.ssp_wave > 1200) & (ssp_data.ssp_wave < 3000)
 
     L_UV_unit = calc_rest_uv_luminosity(
         ssp_data.ssp_wave, ssp_data.ssp_flux, uv_tophat_mask, ssp_weights, frac_trans

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -5,8 +5,7 @@ from diffsky.experimental.kernels import mc_phot_kernels as mcpk
 from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-
-# from jax.debug import print
+from jax.debug import print
 
 LGMET_SCATTER = 0.2
 
@@ -136,6 +135,8 @@ def compute_uv_luminosity(
     )  # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
     frac_trans = _res_dust[1]  # ftrans.shape = (n_gals, n_bands, n_age)
     # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
+
+    print("frac_trans.shape:{}", frac_trans.shape)
 
     _mstar = 10**logsm_obs
     L_UV_cgs = L_UV_unit * frac_trans * L_SUN_CGS * _mstar  # [erg/s]

--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -140,4 +140,4 @@ def compute_uv_luminosity(
 
     L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
 
-    return L_UV_cgs, frac_trans
+    return L_UV_cgs


### PR DESCRIPTION
This PR brings in the following new capabilities:

- `uv_luminosity` calculates restframe UV Luminosity, useful in calculating quantities like H-alpha to UV ratio, a burstiness probe.
- `emline_luminosity` computes emission line luminosity for any line, mostly following diffsky's [mc_phot_kernels](diffsky/experimental/kernels/mc_phot_kernels.py)
- `emline_luminosity` computes any emission line luminosity function, designed based on [get_halpha_luminosity_func](https://github.com/ArgonneCPAC/diffhtwo/blob/0cb54ed49b9af020ec45d9373cdfe8a9769895ac/diffhtwo/experimental/halpha_luminosity.py#L56)
- `n_mag_opt` modified to calculate loss due to halpha LF based on these new kernels