### PR TITLE
Make sky_area_degsq non-default

### DIFF
--- a/diffhtwo/experimental/optimizers/phot_and_emline_opt.py
+++ b/diffhtwo/experimental/optimizers/phot_and_emline_opt.py
@@ -85,6 +85,7 @@ def get_phot_loss(
     mag_thresh,
     lc_z_min,
     lc_z_max,
+    lc_sky_area_degsq,
     lc_vol_mpc3,
     t_table,
     ssp_data,
@@ -97,11 +98,10 @@ def get_phot_loss(
     num_halos=1000,
     lgmp_min=10.0,
     lgmp_max=mc_hosts.LGMH_MAX,
-    sky_area_degsq=0.1,
 ):
     # generate lightcone and photometry data
     lc_halopop = weighted_lc_halos(
-        ran_key, num_halos, lc_z_min, lc_z_max, lgmp_min, lgmp_max, sky_area_degsq
+        ran_key, num_halos, lc_z_min, lc_z_max, lgmp_min, lgmp_max, lc_sky_area_degsq
     )
 
     lg_n_model, _ = n_mag_kern(
@@ -145,6 +145,7 @@ def get_emline_loss(
     lg_n_thresh,
     lc_z_min,
     lc_z_max,
+    lc_sky_area_degsq,
     lc_vol_mpc3,
     t_table,
     ssp_data,
@@ -157,10 +158,9 @@ def get_emline_loss(
     num_halos=1000,
     lgmp_min=10.0,
     lgmp_max=mc_hosts.LGMH_MAX,
-    sky_area_degsq=0.1,
 ):
     lc_halopop = weighted_lc_halos(
-        ran_key, num_halos, lc_z_min, lc_z_max, lgmp_min, lgmp_max, sky_area_degsq
+        ran_key, num_halos, lc_z_min, lc_z_max, lgmp_min, lgmp_max, lc_sky_area_degsq
     )
     L_emline_cgs, _ = emline_luminosity.compute_emline_luminosity(
         ran_key,
@@ -211,6 +211,7 @@ def _loss_phot_kern(
     mag_thresh,
     lc_z_min,
     lc_z_max,
+    lc_sky_area_degsq,
     lc_vol_mpc3,
     t_table,
     ssp_data,
@@ -249,6 +250,7 @@ def _loss_phot_kern(
         mag_thresh,
         lc_z_min,
         lc_z_max,
+        lc_sky_area_degsq,
         lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -279,6 +281,7 @@ _L_pk = (
     0,
     0,
     0,
+    0,
     None,
     None,
     0,
@@ -303,9 +306,10 @@ def _loss_emline_kern(
     lg_emline_LF_target,
     lg_emline_Lbin_edges,
     lg_n_thresh,
-    emline_lc_z_min,
-    emline_lc_z_max,
-    emline_lc_vol_mpc3,
+    lc_z_min,
+    lc_z_max,
+    lc_sky_area_degsq,
+    lc_vol_mpc3,
     t_table,
     ssp_data,
     mzr_params,
@@ -331,9 +335,10 @@ def _loss_emline_kern(
         lg_emline_LF_target,
         lg_emline_Lbin_edges,
         lg_n_thresh,
-        emline_lc_z_min,
-        emline_lc_z_max,
-        emline_lc_vol_mpc3,
+        lc_z_min,
+        lc_z_max,
+        lc_sky_area_degsq,
+        lc_vol_mpc3,
         t_table,
         ssp_data,
         diffstarpop_params,
@@ -362,6 +367,7 @@ def _loss_phot_and_emline_multi_z(
     mag_thresh,
     lc_z_min,
     lc_z_max,
+    lc_sky_area_degsq,
     lc_vol_mpc3,
     t_table,
     ssp_data,
@@ -376,6 +382,7 @@ def _loss_phot_and_emline_multi_z(
     lg_emline_Lbin_edges,
     emline_lc_z_min,
     emline_lc_z_max,
+    emline_lc_sky_area_degsq,
     emline_lc_vol_mpc3,
 ):
     phot_multi_z_loss_args = (
@@ -392,6 +399,7 @@ def _loss_phot_and_emline_multi_z(
         mag_thresh,
         lc_z_min,
         lc_z_max,
+        lc_sky_area_degsq,
         lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -419,6 +427,7 @@ def _loss_phot_and_emline_multi_z(
                 lg_n_thresh,
                 emline_lc_z_min[line][z],
                 emline_lc_z_max[line][z],
+                emline_lc_sky_area_degsq[line][z],
                 emline_lc_vol_mpc3[line][z],
                 t_table,
                 ssp_data,
@@ -454,6 +463,7 @@ def fit_phot_and_emline_multi_z(
     mag_thresh,
     lc_z_min,
     lc_z_max,
+    lc_sky_area_degsq,
     lc_vol_mpc3,
     t_table,
     ssp_data,
@@ -468,6 +478,7 @@ def fit_phot_and_emline_multi_z(
     lg_emline_Lbin_edges,
     emline_lc_z_min,
     emline_lc_z_max,
+    emline_lc_sky_area_degsq,
     emline_lc_vol_mpc3,
     n_steps=2,
     step_size=0.1,
@@ -488,6 +499,7 @@ def fit_phot_and_emline_multi_z(
         mag_thresh,
         lc_z_min,
         lc_z_max,
+        lc_sky_area_degsq,
         lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -502,6 +514,7 @@ def fit_phot_and_emline_multi_z(
         lg_emline_Lbin_edges,
         emline_lc_z_min,
         emline_lc_z_max,
+        emline_lc_sky_area_degsq,
         emline_lc_vol_mpc3,
     )
 

--- a/diffhtwo/experimental/tests/test_phot_and_emline_opt.py
+++ b/diffhtwo/experimental/tests/test_phot_and_emline_opt.py
@@ -71,7 +71,8 @@ def test_phot_and_emline_opt(ssp_data):
 
     lc_z_min = zbins[z_idx][0]
     lc_z_max = zbins[z_idx][1]
-    lc_vol_mpc3 = zbin_volume(0.1, zlow=lc_z_min, zhigh=lc_z_max).value
+    lc_sky_area_degsq = 0.1
+    lc_vol_mpc3 = zbin_volume(lc_sky_area_degsq, zlow=lc_z_min, zhigh=lc_z_max).value
 
     tcurves = [
         retrieve_tcurves.MegaCam_uS,
@@ -124,6 +125,7 @@ def test_phot_and_emline_opt(ssp_data):
         mag_thresh,
         lc_z_min,
         lc_z_max,
+        lc_sky_area_degsq,
         lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -166,6 +168,7 @@ def test_phot_and_emline_opt(ssp_data):
         mag_thresh,
         lc_z_min,
         lc_z_max,
+        lc_sky_area_degsq,
         lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -186,8 +189,9 @@ def test_phot_and_emline_opt(ssp_data):
     emline_wave_aa = 6000
     emline_lc_z_min = 0.39
     emline_lc_z_max = 0.41
+    emline_lc_sky_area_degsq = 0.1
     emline_lc_vol_mpc3 = zbin_volume(
-        0.1, zlow=emline_lc_z_min, zhigh=emline_lc_z_max
+        emline_lc_sky_area_degsq, zlow=emline_lc_z_min, zhigh=emline_lc_z_max
     ).value
     lg_emline_LF_data = jnp.array(
         [
@@ -243,6 +247,7 @@ def test_phot_and_emline_opt(ssp_data):
         lg_n_thresh,
         emline_lc_z_min,
         emline_lc_z_max,
+        emline_lc_sky_area_degsq,
         emline_lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -266,6 +271,7 @@ def test_phot_and_emline_opt(ssp_data):
         lg_n_thresh,
         emline_lc_z_min,
         emline_lc_z_max,
+        emline_lc_sky_area_degsq,
         emline_lc_vol_mpc3,
         t_table,
         ssp_data,
@@ -278,35 +284,50 @@ def test_phot_and_emline_opt(ssp_data):
 
     # test multi-z loss
     ran_key, n_key = jran.split(ran_key, 2)
+
+    # phot args
     lg_n_data_err_lh_multi_z = jnp.stack([lg_n_data_err_lh, lg_n_data_err_lh], axis=0)
     lh_centroids_multi_z = jnp.stack([lh_centroids, lh_centroids], axis=0)
     dmag_centroids_multi_z = jnp.stack([dmag_centroids, dmag_centroids], axis=0)
     lc_z_min_multi_z = jnp.array([lc_z_min, lc_z_min])
     lc_z_max_multi_z = jnp.array([lc_z_max, lc_z_max])
+    lc_sky_area_degsq_multi_z = jnp.array([lc_sky_area_degsq, lc_sky_area_degsq])
     lc_vol_mpc3_multi_z = jnp.array([lc_vol_mpc3, lc_vol_mpc3])
     precomputed_ssp_mag_table_multi_z = jnp.stack(
         [precomputed_ssp_mag_table, precomputed_ssp_mag_table], axis=0
     )
     z_phot_table_multi_z = jnp.stack([z_phot_table, z_phot_table], axis=0)
     wave_eff_table_multi_z = jnp.stack([wave_eff_table, wave_eff_table], axis=0)
-    lg_emline_LF_data_multi_z = jnp.stack(
-        [lg_emline_LF_data, lg_emline_LF_data], axis=0
-    )
-    lg_emline_Lbin_edges_data_multi_z = jnp.stack(
-        [lg_emline_Lbin_edges_data, lg_emline_Lbin_edges_data], axis=0
-    )
-    emline_lc_z_min_multi_z = jnp.array([0.39, 0.83])
-    emline_lc_z_max_multi_z = jnp.array([0.41, 0.85])
-    emline_lc_vol_mpc3_multi_z = jnp.array(
-        [
-            zbin_volume(
-                0.1, zlow=emline_lc_z_min_multi_z[0], zhigh=emline_lc_z_max_multi_z[0]
-            ).value,
-            zbin_volume(
-                0.1, zlow=emline_lc_z_min_multi_z[1], zhigh=emline_lc_z_max_multi_z[1]
-            ).value,
-        ]
-    )
+
+    # emline args
+    emline_wave_aa = [emline_wave_aa]
+    lg_emline_LF_data_multi_z = [
+        jnp.stack([lg_emline_LF_data, lg_emline_LF_data], axis=0)
+    ]
+    lg_emline_Lbin_edges_data_multi_z = [
+        jnp.stack([lg_emline_Lbin_edges_data, lg_emline_Lbin_edges_data], axis=0)
+    ]
+    emline_lc_z_min_multi_z = [jnp.array([0.39, 0.83])]
+    emline_lc_z_max_multi_z = [jnp.array([0.41, 0.85])]
+    emline_lc_sky_area_degsq_multi_z = [
+        jnp.array([emline_lc_sky_area_degsq, emline_lc_sky_area_degsq])
+    ]
+    emline_lc_vol_mpc3_multi_z = [
+        jnp.array(
+            [
+                zbin_volume(
+                    emline_lc_sky_area_degsq,
+                    zlow=emline_lc_z_min_multi_z[0],
+                    zhigh=emline_lc_z_max_multi_z[0],
+                ).value,
+                zbin_volume(
+                    emline_lc_sky_area_degsq,
+                    zlow=emline_lc_z_min_multi_z[1],
+                    zhigh=emline_lc_z_max_multi_z[1],
+                ).value,
+            ]
+        )
+    ]
 
     args = (
         lg_n_data_err_lh_multi_z,
@@ -321,6 +342,7 @@ def test_phot_and_emline_opt(ssp_data):
         mag_thresh,
         lc_z_min_multi_z,
         lc_z_max_multi_z,
+        lc_sky_area_degsq_multi_z,
         lc_vol_mpc3_multi_z,
         t_table,
         ssp_data,
@@ -335,6 +357,7 @@ def test_phot_and_emline_opt(ssp_data):
         lg_emline_Lbin_edges_data_multi_z,
         emline_lc_z_min_multi_z,
         emline_lc_z_max_multi_z,
+        emline_lc_sky_area_degsq_multi_z,
         emline_lc_vol_mpc3_multi_z,
     )
 


### PR DESCRIPTION
This PR makes the `sky_area_degsq` arg in gradient descent functions non-default to make the user conscious about that and supply the comoving volume accordingly through args like `lc_vol_mpc3`.