### PR TITLE
Precompute UV luminosity and append to ssp_data

### DIFF
--- a/diffhtwo/experimental/uv_luminosity.py
+++ b/diffhtwo/experimental/uv_luminosity.py
@@ -5,16 +5,11 @@ import jax
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_debug_nans", True)
 jax.config.update("jax_debug_infs", True)
+from collections import namedtuple
+
 import jax.numpy as jnp
-from diffsky.dustpop import tw_dustpop_mono_noise
-from diffsky.experimental import mc_diffstarpop_wrappers as mcdw
-from diffsky.experimental.kernels import mc_phot_kernels as mcpk
-from diffsky.experimental.kernels import ssp_weight_kernels as sspwk
 from jax import jit as jjit
 from jax import vmap
-from jax.debug import print
-
-LGMET_SCATTER = 0.2
 
 # copied from astropy.constants.L_sun.cgs.value
 L_SUN_CGS = jnp.array(3.828e33, dtype="float64")
@@ -32,127 +27,33 @@ interp_vmap = jjit(vmap(jnp.interp, in_axes=_A))
 _B = (None, None, 1)
 interp_vmap2 = jjit(vmap(interp_vmap, in_axes=_B))
 
-_D = (None, None, 0, 0, 0, None, 0, 0, 0, None)
-_calc_dust_ftrans_vmap = jjit(
-    vmap(
-        tw_dustpop_mono_noise.calc_ftrans_singlegal_singlewave_from_dustpop_params,
-        in_axes=_D,
-    )
-)
-
 
 @jjit
 def precompute_uv_luminosity(ssp_data):
+    """get uv_luminosity in units of erg/s/Msun"""
+
     uv_luminosity_per_hz = interp_vmap2(
         UV_WAVELENGTH_AA, ssp_data.ssp_wave, ssp_data.ssp_flux
     ).T
-    # get uv_luminosity in units of Lsun/Msun
-    uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz
+
+    uv_luminosity = UV_FREQUENCY_HZ * uv_luminosity_per_hz * L_SUN_CGS
     return uv_luminosity
 
 
 @jjit
-def _calc_singlegal_rest_uv_luminosity(precomputed_uv_luminosity, ssp_weights, ftrans):
-    """
-    precomputed_uv_luminosity: (nmet, nage)
-    ssp_weights: (n_met, n_age)
-    ftrans : (nage,)
-    """
+def append_uv_luminosity_to_ssp_data(ssp_data):
+    emline_wave_dict = ssp_data.ssp_emline_wave._asdict()
+    emline_wave_dict["UV"] = 1500.00
+    EmLineWave = namedtuple("EmLineWave", emline_wave_dict.keys())
+    emline_wave_with_uv = EmLineWave(**emline_wave_dict)
 
-    n_met, n_age = ssp_weights.shape
-
-    # broadcast ftrans due to dust across metallicity
-    ftrans = ftrans.reshape(1, n_age)
-
-    # get ssp weighted uv luminosity with ftrans due to dust incorporated. Units: [Lsun/Msun]
-    integrand = precomputed_uv_luminosity * ssp_weights * ftrans
-    uv_luminosity_weighted_w_dust = jnp.sum(integrand, axis=(0, 1))
-
-    return uv_luminosity_weighted_w_dust
-
-
-_S = (None, 0, 0)
-_calc_galpop_rest_uv_luminosity = vmap(_calc_singlegal_rest_uv_luminosity, in_axes=_S)
-
-
-@jjit
-def compute_uv_luminosity(
-    ran_key,
-    z_obs,
-    t_obs,
-    mah_params,
-    diffstarpop_params,
-    spspop_params,
-    mzr_params,
-    scatter_params,
-    t_table,
-    ssp_data,
-    precomputed_uv_luminosity,
-    cosmo_params,
-    fb,
-    lgmet_scatter=LGMET_SCATTER,
-    n_t_table=mcdw.N_T_TABLE,
-    dust=True,
-):
-    phot_randoms, sfh_params = mcpk.get_mc_phot_randoms(
-        ran_key, diffstarpop_params, mah_params, cosmo_params
+    precomputed_uv_luminosity = precompute_uv_luminosity(ssp_data)
+    emline_luminosity_with_uv = jnp.concatenate(
+        [ssp_data.ssp_emline_luminosity, precomputed_uv_luminosity[..., None]], axis=-1
     )
 
-    t_table, sfh_table, logsm_obs, logssfr_obs = mcdw.compute_diffstar_info(
-        mah_params, sfh_params, t_obs, cosmo_params, fb, n_t_table
+    ssp_data = ssp_data._replace(
+        ssp_emline_wave=emline_wave_with_uv,
+        ssp_emline_luminosity=emline_luminosity_with_uv,
     )
-
-    age_weights_smooth, lgmet_weights = sspwk.get_smooth_ssp_weights(
-        t_table, sfh_table, logsm_obs, ssp_data, t_obs, mzr_params, LGMET_SCATTER
-    )
-
-    _res = sspwk.compute_burstiness(
-        phot_randoms.uran_pburst,
-        phot_randoms.mc_is_q,
-        logsm_obs,
-        logssfr_obs,
-        age_weights_smooth,
-        lgmet_weights,
-        ssp_data,
-        spspop_params.burstpop_params,
-    )
-
-    ssp_weights, burst_params, mc_sfh_type = _res
-
-    ftrans_args = (
-        spspop_params.dustpop_params,
-        UV_WAVELENGTH_AA,
-        logsm_obs,
-        logssfr_obs,
-        z_obs,
-        ssp_data.ssp_lg_age_gyr,
-        phot_randoms.uran_av,
-        phot_randoms.uran_delta,
-        phot_randoms.uran_funo,
-        scatter_params,
-    )
-
-    # _res_dust = ftrans, noisy_ftrans, dust_params, noisy_dust_params
-    _res_dust = _calc_dust_ftrans_vmap(*ftrans_args)
-
-    # frac_trans.shape = (n_gals, n_age)
-    # dust_params = _res_dust[3]  # fields = ('av', 'delta', 'funo')
-    frac_trans = _res_dust[1]
-
-    L_UV_unit = _calc_galpop_rest_uv_luminosity(
-        precomputed_uv_luminosity, ssp_weights, frac_trans
-    )  # [Lsun/Msun]
-
-    _mstar = 10**logsm_obs
-
-    L_UV_cgs = L_UV_unit * L_SUN_CGS * _mstar  # [erg/s]
-
-    # no dust
-    frac_trans_nodust = jnp.ones_like(frac_trans)
-    L_UV_unit_nodust = _calc_galpop_rest_uv_luminosity(
-        precomputed_uv_luminosity, ssp_weights, frac_trans_nodust
-    )  # [Lsun/Msun]
-
-    L_UV_cgs_nodust = L_UV_unit_nodust * L_SUN_CGS * _mstar  # [erg/s]
-
-    return L_UV_cgs, L_UV_cgs_nodust
+    return ssp_data


### PR DESCRIPTION
This PR updates the units of UV Luminosity in `precompute_uv_luminosity` function to `erg/s/Msun` to match the emission line units in [load_ssp_templates](https://github.com/ArgonneCPAC/dsps/blob/2ca3ce4285e16a330b83248208bcafa086036e9e/dsps/data_loaders/load_ssp_data.py#L53). Also, `append_uv_luminosity_to_ssp_data` is introduced which adds in UV luminosity to ssp_data block.